### PR TITLE
DM-35057: Hide code cells through new HTML display settings

### DIFF
--- a/src/timessquare/domain/nbhtml.py
+++ b/src/timessquare/domain/nbhtml.py
@@ -30,7 +30,7 @@ class NbHtmlModel(BaseModel):
     html_hash: str
     """A sha256 hash of the HTML content."""
 
-    parameters: Dict[str, Any]
+    values: Dict[str, Any]
     """The parameter values, keyed by parameter name.
 
     Values are native Python types (i.e., string values for parameters
@@ -73,7 +73,7 @@ class NbHtmlModel(BaseModel):
             page_name=page_id.name,
             html=html,
             html_hash=html_hash.hexdigest(),
-            parameters=page_id.values,
+            values=page_id.values,
             date_executed=noteburst_result.finish_time,
             date_rendered=datetime.utcnow(),
             execution_duration=td,

--- a/src/timessquare/domain/page.py
+++ b/src/timessquare/domain/page.py
@@ -388,8 +388,8 @@ class PageModel:
         if parameter_name_pattern.match(name) is None:
             raise ParameterNameValidationError(name)
 
-    def resolve_and_validate_parameters(
-        self, requested_parameters: Mapping[str, Any]
+    def resolve_and_validate_values(
+        self, requested_values: Mapping[str, Any]
     ) -> Dict[str, Any]:
         """Resolve and validate parameter values for a notebook based on
         a possibly incomplete user request.
@@ -404,7 +404,7 @@ class PageModel:
         # the default. Avoid extraneous parameters from the request for
         # security.
         resolved_values = {
-            name: requested_parameters.get(name, schema.default)
+            name: requested_values.get(name, schema.default)
             for name, schema in self.parameters.items()
         }
 
@@ -431,11 +431,11 @@ class PageModel:
         specified parameter values.
 
         **Note**: parameter values are not validated. Use
-        resolve_and_validate_parameters first.
+        resolve_and_validate_values first.
 
         Parameters
         ----------
-        requested_parameters : `dict`
+        values : `dict`
             Parameter values.
 
         Returns

--- a/src/timessquare/domain/page.py
+++ b/src/timessquare/domain/page.py
@@ -14,8 +14,6 @@ import jinja2
 import jsonschema.exceptions
 import nbformat
 from jsonschema import Draft202012Validator
-from nbconvert.exporters.html import HTMLExporter
-from traitlets.config import Config
 
 from timessquare.exceptions import (
     PageNotebookFormatError,
@@ -460,18 +458,6 @@ class PageModel:
 
         # Render notebook back to a string and return
         return PageModel.write_ipynb(notebook)
-
-    def render_html(self, ipynb: str) -> str:
-        """Render a notebook into HTML."""
-        config = Config()
-        config.HTMLExporter.exclude_input = True
-        config.HTMLExporter.exclude_input_prompt = True
-        config.HTMLExporter.exclude_output_prompt = True
-        exporter = HTMLExporter(config=config)
-
-        notebook = PageModel.read_ipynb(ipynb)
-        html, resources = exporter.from_notebook_node(notebook)
-        return html
 
 
 @dataclass

--- a/src/timessquare/domain/page.py
+++ b/src/timessquare/domain/page.py
@@ -15,6 +15,7 @@ import jsonschema.exceptions
 import nbformat
 from jsonschema import Draft202012Validator
 from nbconvert.exporters.html import HTMLExporter
+from traitlets.config import Config
 
 from timessquare.exceptions import (
     PageNotebookFormatError,
@@ -462,8 +463,13 @@ class PageModel:
 
     def render_html(self, ipynb: str) -> str:
         """Render a notebook into HTML."""
+        config = Config()
+        config.HTMLExporter.exclude_input = True
+        config.HTMLExporter.exclude_input_prompt = True
+        config.HTMLExporter.exclude_output_prompt = True
+        exporter = HTMLExporter(config=config)
+
         notebook = PageModel.read_ipynb(ipynb)
-        exporter = HTMLExporter()
         html, resources = exporter.from_notebook_node(notebook)
         return html
 

--- a/src/timessquare/handlers/v1/handlers.py
+++ b/src/timessquare/handlers/v1/handlers.py
@@ -241,9 +241,9 @@ async def get_page_html(
 ) -> HTMLResponse:
     """Get the rendered HTML of a notebook."""
     page_service = context.page_service
-    parameters = context.request.query_params
+    parameter_values = context.request.query_params
     async with context.session.begin():
-        html = await page_service.get_html(name=page, parameters=parameters)
+        html = await page_service.get_html(name=page, values=parameter_values)
 
     if not html:
         raise HTTPException(status_code=404, detail="HTML not available")
@@ -262,9 +262,9 @@ async def get_page_html_status(
     context: RequestContext = Depends(context_dependency),
 ) -> HtmlStatus:
     page_service = context.page_service
-    parameters = context.request.query_params
+    parameter_values = context.request.query_params
     async with context.session.begin():
-        html = await page_service.get_html(name=page, parameters=parameters)
+        html = await page_service.get_html(name=page, values=parameter_values)
 
     return HtmlStatus.from_html(html=html, request=context.request)
 

--- a/src/timessquare/handlers/v1/handlers.py
+++ b/src/timessquare/handlers/v1/handlers.py
@@ -241,9 +241,10 @@ async def get_page_html(
 ) -> HTMLResponse:
     """Get the rendered HTML of a notebook."""
     page_service = context.page_service
-    parameter_values = context.request.query_params
     async with context.session.begin():
-        html = await page_service.get_html(name=page, values=parameter_values)
+        html = await page_service.get_html(
+            name=page, query_params=context.request.query_params
+        )
 
     if not html:
         raise HTTPException(status_code=404, detail="HTML not available")
@@ -262,9 +263,10 @@ async def get_page_html_status(
     context: RequestContext = Depends(context_dependency),
 ) -> HtmlStatus:
     page_service = context.page_service
-    parameter_values = context.request.query_params
     async with context.session.begin():
-        html = await page_service.get_html(name=page, values=parameter_values)
+        html = await page_service.get_html(
+            name=page, query_params=context.request.query_params
+        )
 
     return HtmlStatus.from_html(html=html, request=context.request)
 

--- a/src/timessquare/handlers/v1/models.py
+++ b/src/timessquare/handlers/v1/models.py
@@ -369,7 +369,14 @@ class HtmlStatus(BaseModel):
 
             return cls(available=False, html_url=html_url, html_hash=None)
         else:
-            qs = urlencode(html.values)
+            query_params: Dict[str, Any] = {}
+            query_params.update(html.values)
+            # Add display settings
+            if html.hide_code:
+                query_params["ts_hide_code"] = "1"
+            else:
+                query_params["ts_hide_code"] = "0"
+            qs = urlencode(query_params)
             if qs:
                 html_url = f"{base_html_url}?{qs}"
             else:

--- a/src/timessquare/handlers/v1/models.py
+++ b/src/timessquare/handlers/v1/models.py
@@ -369,7 +369,7 @@ class HtmlStatus(BaseModel):
 
             return cls(available=False, html_url=html_url, html_hash=None)
         else:
-            qs = urlencode(html.parameters)
+            qs = urlencode(html.values)
             if qs:
                 html_url = f"{base_html_url}?{qs}"
             else:

--- a/src/timessquare/services/page.py
+++ b/src/timessquare/services/page.py
@@ -242,10 +242,9 @@ class PageService:
             if noteburst_response.status == NoteburstJobStatus.complete:
                 ipynb = noteburst_response.ipynb
                 assert ipynb
-                html = page_instance.page.render_html(ipynb)
                 nbhtml = NbHtmlModel.create_from_noteburst_result(
-                    page_id=page_instance,
-                    html=html,
+                    page_instance=page_instance,
+                    ipynb=ipynb,
                     noteburst_result=noteburst_response,
                 )
                 # FIXME make lifetime a setting of page for pages that aren't

--- a/src/timessquare/services/page.py
+++ b/src/timessquare/services/page.py
@@ -140,9 +140,9 @@ class PageService:
         This is useful for the `add_page` and `update_page` methods to start
         notebook execution as soon as possible.
         """
-        resolved_parameters = page.resolve_and_validate_parameters({})
+        resolved_values = page.resolve_and_validate_values({})
         page_instance = PageInstanceModel(
-            name=page.name, values=resolved_parameters, page=page
+            name=page.name, values=resolved_values, page=page
         )
         await self._request_noteburst_execution(page_instance)
 
@@ -157,7 +157,7 @@ class PageService:
             await self.soft_delete_page(page)
 
     async def render_page_template(
-        self, name: str, parameters: Mapping[str, Any]
+        self, name: str, values: Mapping[str, Any]
     ) -> str:
         """Render a page's jupyter notebook, with the given parameter values.
 
@@ -165,17 +165,17 @@ class PageService:
         ----------
         name : `str`
             Name (URL slug) of the page.
-        parameters : `dict`
-            Parameter values, keyed by parameter names. If parameters are
+        values : `dict`
+            Parameter values, keyed by parameter names. If values are
             missing, the default value is used instead.
         """
         page = await self.get_page(name)
-        resolved_parameters = page.resolve_and_validate_parameters(parameters)
-        rendered_notebook = page.render_parameters(resolved_parameters)
+        resolved_values = page.resolve_and_validate_values(values)
+        rendered_notebook = page.render_parameters(resolved_values)
         return rendered_notebook
 
     async def get_html(
-        self, *, name: str, parameters: Mapping[str, Any]
+        self, *, name: str, values: Mapping[str, Any]
     ) -> Optional[NbHtmlModel]:
         """Get the HTML for a page given a set of parameter values, first
         from a cache or triggering a rendering if not available.
@@ -187,7 +187,7 @@ class PageService:
             not presently available.
         """
         page = await self.get_page(name)
-        resolved_parameters = page.resolve_and_validate_parameters(parameters)
+        resolved_parameters = page.resolve_and_validate_values(values)
 
         page_instance = PageInstanceModel(
             name=page.name, values=resolved_parameters, page=page
@@ -207,13 +207,13 @@ class PageService:
     async def _get_html_from_noteburst_job(
         self, page_instance: PageInstanceModel
     ) -> Optional[NbHtmlModel]:
-        """Convert a noteburst job for a given page and parameters into
+        """Convert a noteburst job for a given page and parameter values into
         HTML (caching that HTML as well), and triggering a new noteburst
 
         Parameters
         ----------
         page_instance : `PageInstanceModel`
-            The page instance (consisting of resolved parameters).
+            The page instance (consisting of resolved parameter values).
 
         Returns
         -------

--- a/src/timessquare/storage/nbhtmlcache.py
+++ b/src/timessquare/storage/nbhtmlcache.py
@@ -7,7 +7,6 @@ from typing import Optional
 import aioredis
 
 from timessquare.domain.nbhtml import NbHtmlModel
-from timessquare.domain.page import PageInstanceIdModel
 
 from .redisbase import RedisStore
 
@@ -36,7 +35,5 @@ class NbHtmlCacheStore(RedisStore[NbHtmlModel]):
             The lifetime for the record in seconds. `None` to cache the record
             indefinitely.
         """
-        page_id = PageInstanceIdModel(
-            name=nbhtml.page_name, values=dict(nbhtml.values)
-        )
-        await super().store(page_id, nbhtml, lifetime=lifetime)
+        key = nbhtml.create_key()
+        await super().store(key, nbhtml, lifetime=lifetime)

--- a/src/timessquare/storage/nbhtmlcache.py
+++ b/src/timessquare/storage/nbhtmlcache.py
@@ -37,6 +37,6 @@ class NbHtmlCacheStore(RedisStore[NbHtmlModel]):
             indefinitely.
         """
         page_id = PageInstanceIdModel(
-            name=nbhtml.page_name, values=dict(nbhtml.parameters)
+            name=nbhtml.page_name, values=dict(nbhtml.values)
         )
         await super().store(page_id, nbhtml, lifetime=lifetime)

--- a/src/timessquare/storage/redisbase.py
+++ b/src/timessquare/storage/redisbase.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-from base64 import b64encode
 from typing import AsyncIterable, Generic, Optional, Type, TypeVar
 
 import aioredis
@@ -54,12 +52,7 @@ class RedisStore(Generic[T]):
             The unique redis key for this combination of page name and
             parameter values for a given datastore.
         """
-        encoded_parameters_key = b64encode(
-            json.dumps(
-                {k: p for k, p in page_id.values.items()}, sort_keys=True
-            ).encode("utf-8")
-        ).decode("utf-8")
-        return f"{self._key_prefix}/{page_id.name}/{encoded_parameters_key}"
+        return f"{self._key_prefix}/{page_id.cache_key}"
 
     async def store(
         self,


### PR DESCRIPTION
We want the default Times Square HTML rendering behaviour to be to suppress both code cells and prompts in order to avoid the uncanny valley of an interactive notebook, while also increasing the polish of notebooks as dashboards.

To accomplish this, while also allowing the user to see an HTML rendering that includes code cells, this PR introduces "display settings" that affect the HTML rendering, akin to how the parameter system affects the notebook computation. When Times Square converts an executed notebook to HTML, it now creates and caches HTML renders for each combination of display settings.

Right now the only display setting is for hiding/showing code input cells. It's controllable by a `?ts_hide_code=1` (or `=0`) URL query string parameter for the `/:page/html` and `/:page/htmlstatus` endpoints.