### PR TITLE
Improve /html error message

### DIFF
--- a/src/timessquare/handlers/v1/handlers.py
+++ b/src/timessquare/handlers/v1/handlers.py
@@ -247,7 +247,9 @@ async def get_page_html(
         )
 
     if not html:
-        raise HTTPException(status_code=404, detail="HTML not available")
+        raise HTTPException(
+            status_code=404, detail="Computing the notebook..."
+        )
 
     return HTMLResponse(html.html)
 


### PR DESCRIPTION
Change the 404 message on the /html endpoint since it's user-visible in the early version of the UI that lacks a real loading page.