### PR TITLE
DM-40250: Delete nbhtml instances from redis when a page updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Collect fragments into this file with: scriv collect --version X.Y.Z
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.9.1'></a>
+## 0.9.1 (2023-07-31)
+
+### Bug fixes
+
+- When a page is updated (e.g., from a GitHub pull request merge), the HTML renders for that page are cleared.
+- Fixed a bug where updating a page and executing it with defaults would result in two requests to Noteburst.
+- Deleting a page now deletes the page's HTML renders.
+
 <a id='changelog-0.9.0'></a>
 
 ## 0.9.0 (2023-07-27)

--- a/changelog.d/20230731_162220_jsick_DM_40250.md
+++ b/changelog.d/20230731_162220_jsick_DM_40250.md
@@ -1,0 +1,5 @@
+### Bug fixes
+
+- When a page is updated (e.g., from a GitHub pull request merge), the HTML renders for that page are cleared.
+- Fixed a bug where updating a page and executing it with defaults would result in two requests to Noteburst.
+- Deleting a page now deletes the page's HTML renders.

--- a/changelog.d/20230731_162220_jsick_DM_40250.md
+++ b/changelog.d/20230731_162220_jsick_DM_40250.md
@@ -1,5 +1,0 @@
-### Bug fixes
-
-- When a page is updated (e.g., from a GitHub pull request merge), the HTML renders for that page are cleared.
-- Fixed a bug where updating a page and executing it with defaults would result in two requests to Noteburst.
-- Deleting a page now deletes the page's HTML renders.

--- a/src/timessquare/domain/page.py
+++ b/src/timessquare/domain/page.py
@@ -648,16 +648,27 @@ class PageSummaryModel:
 
 
 @dataclass
-class PageInstanceIdModel:
+class PageIdModel:
+    """A domain model that identifies a page and creates a reproducible key
+    string for a page.
+    """
+
+    name: str
+    """The name of the page, which is used as a URL path component (slug)."""
+
+    @property
+    def cache_key_prefix(self) -> str:
+        return f"{self.name}/"
+
+
+@dataclass
+class PageInstanceIdModel(PageIdModel):
     """The domain model that identifies an instance of a page through the
     page's name and values of parameters.
 
     The `cache_key` property produces a reproducible key string, useful as
     a Redis key.
     """
-
-    name: str
-    """The name of the page, which is used as a URL path component (slug)."""
 
     values: dict[str, Any]
     """The values of a page instance's parameters.
@@ -673,7 +684,7 @@ class PageInstanceIdModel:
                 "utf-8"
             )
         ).decode("utf-8")
-        return f"{self.name}/{encoded_values_key}"
+        return f"{super().cache_key_prefix}{encoded_values_key}"
 
 
 @dataclass

--- a/src/timessquare/services/page.py
+++ b/src/timessquare/services/page.py
@@ -212,7 +212,6 @@ class PageService:
         """
         await self._page_store.update_page(page)
         await self._html_store.delete_objects_for_page(page.name)
-        await self.execute_page_with_defaults(page)
 
     async def update_page_and_execute(
         self, page: PageModel, *, enable_retry: bool = True

--- a/src/timessquare/services/page.py
+++ b/src/timessquare/services/page.py
@@ -208,7 +208,6 @@ class PageService:
 
         1. Update the page in Postgres
         2. Delete all cached HTML for the page from redis
-        3. Execute the page with defaults
         """
         await self._page_store.update_page(page)
         await self._html_store.delete_objects_for_page(page.name)
@@ -240,7 +239,7 @@ class PageService:
     async def soft_delete_page(self, page: PageModel) -> None:
         """Soft delete a page by setting its date_deleted field."""
         page.date_deleted = datetime.now(UTC)
-        await self._page_store.update_page(page)
+        await self.update_page_in_store(page)
 
     async def soft_delete_pages_for_repo(self, owner: str, name: str) -> None:
         """Soft delete all pages backed by a specific GitHub repository."""

--- a/src/timessquare/services/page.py
+++ b/src/timessquare/services/page.py
@@ -202,8 +202,16 @@ class PageService:
         )
 
     async def update_page_in_store(self, page: PageModel) -> None:
-        """Update the page in the database."""
+        """Update the page in the database.
+
+        Algorithm is:
+
+        1. Update the page in Postgres
+        2. Delete all cached HTML for the page from redis
+        3. Execute the page with defaults
+        """
         await self._page_store.update_page(page)
+        await self._html_store.delete_objects_for_page(page.name)
         await self.execute_page_with_defaults(page)
 
     async def update_page_and_execute(

--- a/src/timessquare/storage/nbhtmlcache.py
+++ b/src/timessquare/storage/nbhtmlcache.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from redis.asyncio import Redis
 
 from timessquare.domain.nbhtml import NbHtmlModel
+from timessquare.domain.page import PageIdModel
 
 from .redisbase import RedisPageInstanceStore
 
@@ -37,3 +38,8 @@ class NbHtmlCacheStore(RedisPageInstanceStore[NbHtmlModel]):
         """
         key = nbhtml.create_key()
         await super().store_instance(key, nbhtml, lifetime=lifetime)
+
+    async def delete_objects_for_page(self, page_name: str) -> None:
+        """Delete all cached renders for a page."""
+        prefix = PageIdModel(name=page_name).cache_key_prefix
+        await self.delete_all(f"{prefix}*")


### PR DESCRIPTION
- When a page updates, delete existing HTML renders from redis
- Prevent update_page_and_execute from generating duplicate requests to noteburst