### PR TITLE
DM-48733: Another template rendering endpoint

### DIFF
--- a/changelog.d/20250204_171720_danfuchs_idfprod.md
+++ b/changelog.d/20250204_171720_danfuchs_idfprod.md
@@ -1,0 +1,5 @@
+### New features
+
+- `GET /v1/github/rendered/{display_path}` that returns a rendered GitHub-backed notebook template. This route provides the same functionality as `GET /v1/pages/{page}/rendered`, but finds the page based on its GitHub URL path. This is an additional path, all existing functionality, including the existing template rendering path, remains unchanged.
+
+  We need to deploy Times Square to environments where some users should not have permissions to execute notebooks, but they should have permissions to render notebook templates for certain GitHub-based notebooks. This will let us configure that access via methods that apply permissions based on URL paths.

--- a/src/timessquare/handlers/v1/models.py
+++ b/src/timessquare/handlers/v1/models.py
@@ -114,6 +114,16 @@ page_rendered_field = Field(
     ),
 )
 
+github_page_rendered_field: AnyHttpUrl | None = Field(
+    None,
+    examples=["https://example.com/v1/rendered/org/repo/notebook.ipynb"],
+    title="GitHub-backed rendered notebook template URL",
+    description=(
+        "The URL for the source notebook rendered with parameter values "
+        "(JSON-formatted), by GitHub URL path."
+    ),
+)
+
 page_html_field = Field(
     ...,
     examples=["https://example.com/v1/pages/summit-weather/html"],

--- a/src/timessquare/services/page.py
+++ b/src/timessquare/services/page.py
@@ -263,6 +263,28 @@ class PageService:
             missing, the default value is used instead.
         """
         page = await self.get_page(name)
+        return await self._render_page_template(page, values)
+
+    async def render_page_template_by_display_path(
+        self, display_path: str, values: Mapping[str, Any]
+    ) -> str:
+        """Render a GitHub-backed jupyter notebook, with the given parameter
+        values.
+
+        Parameters
+        ----------
+        display_path
+            The path to the notebook in a GitHub URL.
+        values
+            Parameter values, keyed by parameter names. If values are
+            missing, the default value is used instead.
+        """
+        page = await self.get_github_backed_page(display_path)
+        return await self._render_page_template(page, values)
+
+    async def _render_page_template(
+        self, page: PageModel, values: Mapping[str, Any]
+    ) -> str:
         resolved_values = page.resolve_and_validate_values(values)
         return page.render_parameters(resolved_values)
 

--- a/tests/data/times-square-demo/demo.yaml
+++ b/tests/data/times-square-demo/demo.yaml
@@ -9,7 +9,7 @@ parameters:
     description: Amplitude
     default: 4
     minimum: 0
-  lambda:
+  lambd:
     type: number
     description: Wavelength
     default: 2


### PR DESCRIPTION
* Expose template rendering for a GitHub notebook template at a different path. This path includes the GitHub URL path to the notebook. This is an additional path, all existing functionality, including the existing template rendering path, remains unchanged.
* Add this new path to the page info response.

We need to deploy Times Square to environments where some users should not have permissions to execute notebooks, but they should have permissions to render notebook templates for certain GitHub-based notebooks. This will let us configure that access via methods that apply permissions based on URL paths.