### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Collect fragments into this file with: scriv collect --version X.Y.Z
 
 <!-- scriv-insert-here -->
 
+<a id='changelog-0.17.0'></a>
+## 0.17.0 (2025-02-05)
+
+### New features
+
+- `GET /v1/github/rendered/{display_path}` that returns a rendered GitHub-backed notebook template. This route provides the same functionality as `GET /v1/pages/{page}/rendered`, but finds the page based on its GitHub URL path. This is an additional path, all existing functionality, including the existing template rendering path, remains unchanged.
+
+  We need to deploy Times Square to environments where some users should not have permissions to execute notebooks, but they should have permissions to render notebook templates for certain GitHub-based notebooks. This will let us configure that access via methods that apply permissions based on URL paths.
+
 <a id='changelog-0.16.0'></a>
 ## 0.16.0 (2025-01-22)
 

--- a/changelog.d/20250204_171720_danfuchs_idfprod.md
+++ b/changelog.d/20250204_171720_danfuchs_idfprod.md
@@ -1,5 +1,0 @@
-### New features
-
-- `GET /v1/github/rendered/{display_path}` that returns a rendered GitHub-backed notebook template. This route provides the same functionality as `GET /v1/pages/{page}/rendered`, but finds the page based on its GitHub URL path. This is an additional path, all existing functionality, including the existing template rendering path, remains unchanged.
-
-  We need to deploy Times Square to environments where some users should not have permissions to execute notebooks, but they should have permissions to render notebook templates for certain GitHub-based notebooks. This will let us configure that access via methods that apply permissions based on URL paths.


### PR DESCRIPTION
This contains an alternate GitHub-path-based template rendering endpoint so we can further restrict the parts of Times Square that we expose to non-admins. Including this, there are three changes to enable us to implement these restrictions:

* This change (`times-square`)
* [This RSP Jupyter extensions change](https://github.com/lsst-sqre/rsp-jupyter-extensions/pull/42), which uses the new endpoint (`rsp-jupyter-extensions`)
* [This change to the GafaelfawrIngress](https://github.com/lsst-sqre/phalanx/pull/4172/), which restricts non-admins to only the new route

Here are all of the combinations, a checked box means it works:

- [x] g_admin: `times-square` +` rsp-jupyter-extensions` + `ingress`
- [x] g_admin: `times-square` + `rsp-jupyter-extensions`
- [x] g_admin: `times-square` + `ingress`
- [x] g_admin: `times-square`
- [x] g_user: `times-square` +` rsp-jupyter-extensions` + `ingress`
- [x] g_user: `times-square` + `rsp-jupyter-extensions`
- [ ] g_user: `times-square` + `ingress`
- [x] g_user: `times-square`

This Times Square change works with every other change for both admin and non-admin users except for non-admin users using a lab without an updated `rsp-jupyter-extensions`. So:
* **Times Square is safe to release with this change at any time**
* `rsp-jupyter-extensions` is safe to release after this Times Square change is deployed everywhere
* The ingress changes will have to involve some more coordination