### PR TITLE
DM-54766: Add rename-github-owner CLI

### DIFF
--- a/changelog.d/20260423_175430_jsick_org_rename.md
+++ b/changelog.d/20260423_175430_jsick_org_rename.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Added a `times-square rename-github-owner --old <owner> --new <owner> [--dry-run]` CLI command to rewrite the `github_owner` column on pages after a GitHub org or user rename. Existing rows are looked up by their owner/repo strings, so a rename leaves them orphaned until this command rewrites them. The config setting `TS_GITHUB_ORGS` must also be updated to accept webhook events from the new owner name.

--- a/src/timessquare/cli.py
+++ b/src/timessquare/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 from pathlib import Path
+from typing import cast
 
 import click
 import httpx
@@ -18,7 +19,10 @@ from safir.database import (
     stamp_database,
 )
 from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import CursorResult, update
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from timessquare.dbschema.page import SqlPage
 from timessquare.dependencies.redis import redis_dependency
 
 from .config import config
@@ -228,3 +232,78 @@ async def run_nbstripout(
             dry_run=dry_run,
         )
         await db_session.commit()
+
+
+@main.command("rename-github-owner")
+@click.option(
+    "--old",
+    "old_owner",
+    required=True,
+    help="Current github_owner value to rewrite (e.g. lsst-sitcom).",
+)
+@click.option(
+    "--new",
+    "new_owner",
+    required=True,
+    help="Replacement github_owner value (e.g. lsst-so).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Report the affected row count without writing any changes.",
+)
+@run_with_asyncio
+async def rename_github_owner(
+    *, old_owner: str, new_owner: str, dry_run: bool = False
+) -> None:
+    """Rewrite the github_owner column on pages after a GitHub org/user rename.
+
+    Times Square looks pages up by the owner/repo strings stored on each row,
+    so a GitHub org rename leaves existing rows orphaned until this command
+    rewrites them.
+    """
+    engine = create_database_engine(
+        config.database_url, config.database_password
+    )
+    logger = structlog.get_logger("timessquare")
+    if not await is_database_current(engine, logger):
+        raise RuntimeError("Database schema out of date")
+    await engine.dispose()
+    await db_session_dependency.initialize(
+        str(config.database_url), config.database_password.get_secret_value()
+    )
+
+    async for db_session in db_session_dependency():
+        count = await _rename_github_owner_in_db(
+            db_session, old_owner=old_owner, new_owner=new_owner
+        )
+        if dry_run:
+            await db_session.rollback()
+        else:
+            await db_session.commit()
+        logger.info(
+            "Finished renaming github_owner",
+            old_owner=old_owner,
+            new_owner=new_owner,
+            count=count,
+            dry_run=dry_run,
+        )
+
+
+async def _rename_github_owner_in_db(
+    session: AsyncSession, *, old_owner: str, new_owner: str
+) -> int:
+    """Rewrite ``page.github_owner`` from ``old_owner`` to ``new_owner``.
+
+    Returns the number of rows affected. Does not commit; the caller is
+    responsible for committing or rolling back.
+    """
+    result = cast(
+        "CursorResult",
+        await session.execute(
+            update(SqlPage)
+            .where(SqlPage.github_owner == old_owner)
+            .values(github_owner=new_owner)
+        ),
+    )
+    return result.rowcount

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,0 +1,102 @@
+"""Tests for the Times Square CLI."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+import structlog
+from safir.database import (
+    create_database_engine,
+    initialize_database,
+    stamp_database_async,
+)
+from safir.dependencies.db_session import db_session_dependency
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from timessquare.cli import _rename_github_owner_in_db
+from timessquare.config import config
+from timessquare.dbschema import Base
+from timessquare.dbschema.page import SqlPage
+from timessquare.domain.page import PageModel
+from timessquare.domain.pageparameters import PageParameters
+from timessquare.storage.page import PageStore
+
+
+def _make_github_page(
+    *, name: str, github_owner: str, github_repo: str
+) -> PageModel:
+    return PageModel(
+        name=name,
+        ipynb="{}",
+        parameters=PageParameters({}),
+        title=name,
+        date_added=datetime.now(UTC),
+        date_deleted=None,
+        github_owner=github_owner,
+        github_repo=github_repo,
+        repository_path_prefix="",
+        repository_display_path_prefix="",
+        repository_path_stem=name,
+        repository_sidecar_extension=".yaml",
+        repository_source_extension=".ipynb",
+        repository_source_sha="1" * 40,
+        repository_sidecar_sha="1" * 40,
+    )
+
+
+async def _owner_by_name(session: AsyncSession, name: str) -> str | None:
+    statement = select(SqlPage.github_owner).where(SqlPage.name == name)
+    return await session.scalar(statement)
+
+
+@pytest.mark.asyncio
+async def test_rename_github_owner() -> None:
+    """Renaming rewrites matching rows only; a rollback reverts changes."""
+    logger = structlog.get_logger(config.logger_name)
+    engine = create_database_engine(
+        config.database_url, config.database_password.get_secret_value()
+    )
+    await initialize_database(engine, logger, schema=Base.metadata, reset=True)
+    await stamp_database_async(engine)
+    await engine.dispose()
+
+    await db_session_dependency.initialize(
+        str(config.database_url), config.database_password.get_secret_value()
+    )
+    try:
+        async for session in db_session_dependency():
+            store = PageStore(session)
+            store.add(
+                _make_github_page(
+                    name="page-a",
+                    github_owner="lsst-sitcom",
+                    github_repo="foo",
+                )
+            )
+            store.add(
+                _make_github_page(
+                    name="page-b", github_owner="other", github_repo="bar"
+                )
+            )
+            await session.commit()
+
+            # Dry-run path: update then rollback leaves rows untouched.
+            dry_count = await _rename_github_owner_in_db(
+                session, old_owner="lsst-sitcom", new_owner="lsst-so"
+            )
+            await session.rollback()
+            assert dry_count == 1
+            assert await _owner_by_name(session, "page-a") == "lsst-sitcom"
+
+            # Real run: update then commit rewrites only the matching row.
+            count = await _rename_github_owner_in_db(
+                session, old_owner="lsst-sitcom", new_owner="lsst-so"
+            )
+            await session.commit()
+            assert count == 1
+            assert await _owner_by_name(session, "page-a") == "lsst-so"
+            assert await _owner_by_name(session, "page-b") == "other"
+    finally:
+        await db_session_dependency.aclose()


### PR DESCRIPTION
## Summary

- Adds a `times-square rename-github-owner --old <owner> --new <owner> [--dry-run]` CLI command that rewrites the `github_owner` column on `page` rows after a GitHub org or user rename, so existing pages are not orphaned by the rename.
- Motivated by the `lsst-sitcom` → `lsst-so` GitHub organization rename: after the GitHub-side rename the `TS_GITHUB_ORGS` config must be updated to accept webhooks from the new owner, and the existing page rows need their `github_owner` values rewritten to match.
- Updates the new CLI helper's `session` type annotation to `AsyncSession` to match what Safir 15's `db_session_dependency` now yields (the rest of the codebase already uses `AsyncSession`).

## Test plan

- [x] `uv run mypy src/timessquare/cli.py tests/cli_test.py`
- [x] `uv run pytest tests/cli_test.py` (against the real Postgres fixture, including the new `test_rename_github_owner` coverage)
- [x] After merge and deploy, run `times-square rename-github-owner --old lsst-sitcom --new lsst-so --dry-run` to preview, then rerun without `--dry-run` to apply.