### PR TITLE
DM-55384: Reserve the ts_ prefix for notebook parameter names

### DIFF
--- a/changelog.d/20260710_000000_reserve_ts_prefix.md
+++ b/changelog.d/20260710_000000_reserve_ts_prefix.md
@@ -1,0 +1,3 @@
+### New features
+
+- Notebook parameter names may no longer start with the reserved `ts_` prefix, which Squareone uses for viewer-control URL query parameters (such as `ts_hide_code` and `ts_nav_focus`) and strips before requesting renders. A `ts_`-prefixed parameter could never receive a value from the UI, so `validate_parameter_name` now rejects it with an error that names the parameter and explains the reservation. The violation surfaces through the GitHub check-run validation for notebook repositories, and the reservation is documented in the user guide.

--- a/docs/user-guide/index.rst
+++ b/docs/user-guide/index.rst
@@ -4,6 +4,12 @@ User guide
 
 .. toctree::
    :maxdepth: 2
+   :caption: Authoring
+
+   notebook-parameters
+
+.. toctree::
+   :maxdepth: 2
    :caption: Deployment
 
    github-app-config

--- a/docs/user-guide/notebook-parameters.rst
+++ b/docs/user-guide/notebook-parameters.rst
@@ -1,0 +1,28 @@
+###################
+Notebook parameters
+###################
+
+Times Square notebooks can declare *parameters* in their sidecar YAML file (``{notebook}.yaml``).
+Each parameter has a name and a JSON Schema that describes its type, default, and constraints.
+Viewers set parameter values through the page's URL query string, and Times Square substitutes those values into the notebook before it is executed.
+
+Parameter naming rules
+======================
+
+A parameter's name must:
+
+- Be a valid Python variable name: it must start with a letter and contain only letters, numbers, and underscores.
+- Not be a Python keyword (for example, ``lambda`` or ``class``).
+- Not start with the reserved ``ts_`` prefix.
+
+.. _ts-prefix-reservation:
+
+The ``ts_`` prefix is reserved
+------------------------------
+
+The Squareone frontend reserves ``ts_``-prefixed URL query parameters for viewer controls (such as ``ts_hide_code`` and ``ts_nav_focus``) and strips all ``ts_*`` keys before requesting a render.
+A notebook parameter named ``ts_start`` could therefore never receive a value from the UI — it would silently fall back to its schema default even when the browser URL appeared to set it.
+
+To prevent this ambiguity, Times Square rejects any parameter whose name starts with ``ts_``.
+If a notebook's sidecar declares such a parameter, its GitHub check run fails with an error that names the offending parameter and explains the reservation.
+Rename the parameter so it does not start with ``ts_``.

--- a/src/timessquare/domain/pageparameters/_pageparameters.py
+++ b/src/timessquare/domain/pageparameters/_pageparameters.py
@@ -165,8 +165,12 @@ class PageParameters(Mapping):
 
         Parameters must be valid Python variable names, which means they must
         start with a letter and contain only letters, numbers and underscores.
-        They also cannot be Python keywords.
+        They also cannot be Python keywords. The ``ts_`` prefix is reserved
+        for Times Square viewer controls (which the Squareone frontend strips
+        from notebook parameters), so parameter names may not start with it.
         """
+        if name.startswith("ts_"):
+            raise ParameterNameValidationError.for_reserved_prefix(name)
         if (
             str.isidentifier(name)
             and not keyword.iskeyword(name)

--- a/src/timessquare/exceptions.py
+++ b/src/timessquare/exceptions.py
@@ -145,6 +145,23 @@ class ParameterNameValidationError(ParameterSchemaValidationError):
         message = f"Parameter name {name} is not valid."
         return cls(name, message, location=location, field_path=field_path)
 
+    @classmethod
+    def for_reserved_prefix(
+        cls,
+        name: str,
+        location: ErrorLocation | None = None,
+        field_path: list[str] | None = None,
+    ) -> Self:
+        """Create the error for a parameter using the reserved ``ts_``
+        prefix.
+        """
+        message = (
+            f"Parameter name {name} is not valid: the ts_ prefix is "
+            "reserved for Times Square viewer controls. Rename the "
+            "parameter so it does not start with ts_."
+        )
+        return cls(name, message, location=location, field_path=field_path)
+
 
 class ParameterSchemaError(ParameterSchemaValidationError):
     """The parameter's schema is not a valid JSON schema."""

--- a/src/timessquare/storage/github/settingsfiles/_sidecar.py
+++ b/src/timessquare/storage/github/settingsfiles/_sidecar.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Self
 
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from safir.pydantic import HumanTimedelta
 
 from timessquare.domain.page import PersonModel
 from timessquare.domain.pageparameters import PageParameters
 from timessquare.domain.schedule import RunSchedule
 from timessquare.domain.schedulerule import ScheduleRules
+from timessquare.exceptions import ParameterNameValidationError
 
 from ._parameterschema import ParameterSchemaModel
 from ._person import SidecarPersonModel
@@ -105,6 +106,18 @@ class NotebookSidecarFile(BaseModel):
             ),
         ),
     ] = True
+
+    @model_validator(mode="after")
+    def check_parameter_names(self) -> Self:
+        """Validate parameter names so violations (including the reserved
+        ``ts_`` prefix) surface through the GitHub check-run validation path.
+        """
+        for name in self.parameters:
+            try:
+                PageParameters.validate_parameter_name(name)
+            except ParameterNameValidationError as e:
+                raise ValueError(str(e)) from e
+        return self
 
     @classmethod
     def parse_yaml(cls, content: str) -> NotebookSidecarFile:

--- a/tests/domain/pageparameters_test.py
+++ b/tests/domain/pageparameters_test.py
@@ -98,6 +98,25 @@ def test_parameter_name_validation() -> None:
         PageParameters.validate_parameter_name("lambda")
 
 
+def test_reserved_ts_prefix_parameter_name() -> None:
+    """Parameter names starting with ``ts_`` are reserved for Times Square
+    viewer controls and must be rejected.
+    """
+    with pytest.raises(ParameterNameValidationError) as exc_info:
+        PageParameters.validate_parameter_name("ts_start")
+    message = str(exc_info.value)
+    assert "ts_start" in message
+    assert "ts_" in message
+
+    with pytest.raises(ParameterNameValidationError):
+        PageParameters.validate_parameter_name("ts_hide_code")
+
+    # Names that merely contain "ts" but do not start with the reserved
+    # prefix remain valid.
+    PageParameters.validate_parameter_name("counts_ts")
+    PageParameters.validate_parameter_name("ts")
+
+
 def test_parameter_default_exists() -> None:
     name = "myvar"
     schema: dict[str, Any] = {"type": "number", "description": "Test schema"}

--- a/tests/storage/github/settingsfile_test.py
+++ b/tests/storage/github/settingsfile_test.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import ValidationError
 from safir.github.models import GitHubBlobModel
 
+from timessquare.domain.githubcheckrun import Annotation
 from timessquare.domain.pageparameters import (
     DateParameterSchema,
     DatetimeParameterSchema,
@@ -37,6 +38,31 @@ def test_load_sidecar() -> None:
     sidecar = NotebookSidecarFile.parse_yaml(sidecar_path.read_text())
     parameters = sidecar.export_parameters()
     assert parameters is not None
+
+
+def test_reserved_ts_prefix_parameter_rejected() -> None:
+    """A sidecar declaring a ``ts_``-prefixed parameter fails validation so
+    the GitHub check run reports it to notebook authors.
+    """
+    content = (
+        "parameters:\n"
+        "  ts_start:\n"
+        "    type: number\n"
+        "    description: Reserved-prefix parameter\n"
+        "    default: 0\n"
+    )
+    with pytest.raises(ValidationError) as exc_info:
+        NotebookSidecarFile.parse_yaml(content)
+
+    # The check-run path renders the pydantic error into annotations; the
+    # message must name the offending parameter and the reservation rule.
+    annotations = Annotation.from_validation_error(
+        path="notebook.yaml", error=exc_info.value
+    )
+    assert len(annotations) == 1
+    message = annotations[0].message
+    assert "ts_start" in message
+    assert "ts_" in message
 
 
 def test_date_format_parameter() -> None:


### PR DESCRIPTION
## Summary

- Reject notebook parameter names starting with the reserved `ts_` prefix, which Squareone uses for viewer-control URL query parameters (`ts_hide_code`, `ts_nav_focus`) and strips before requesting renders. Such a parameter could never receive a value from the UI, so it now fails validation with a message that names the parameter and explains the reservation.
- Surface the violation to notebook authors through the GitHub check run: an after model validator on `NotebookSidecarFile` re-raises the reservation error as a pydantic `ValidationError`, so it flows through the existing check-run annotation path unchanged.
- Document the `ts_` reservation and the other parameter-naming rules in a new user-guide page.

## Validation steps

- Add a notebook sidecar with a `ts_`-prefixed parameter (e.g. `ts_start`) to a Times Square repo, open a PR, and confirm the Times Square config check run fails with an annotation naming the parameter and the reserved-prefix rule.
- Confirm a parameter named `ts` or `counts_ts` (containing but not starting with `ts_`) still validates.

## References

- Closes #143
- Jira: https://rubinobs.atlassian.net/browse/DM-55384