### PR TITLE
DM-55466: Add configurable HTTP client timeout

### DIFF
--- a/changelog.d/20260710_000000_jsick_DM_55466.md
+++ b/changelog.d/20260710_000000_jsick_DM_55466.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- The shared `httpx.AsyncClient` used for all outbound requests (GitHub API and Noteburst) is now constructed with an explicit, configurable timeout that defaults to 30 seconds, replacing httpx's implicit 5-second default. This raises the ceiling above transient GitHub API slowness that previously tripped `httpx.ReadTimeout` errors during PR check-run setup. The timeout is configurable via the `TS_HTTP_CLIENT_TIMEOUT` environment variable.

--- a/src/timessquare/config.py
+++ b/src/timessquare/config.py
@@ -114,6 +114,18 @@ class Config(BaseSettings):
         description=("URL for the redis instance, used by the worker queue."),
     )
 
+    http_client_timeout: Annotated[
+        int,
+        Field(
+            gt=0,
+            alias="TS_HTTP_CLIENT_TIMEOUT",
+            description=(
+                "The timeout, in seconds, for the shared HTTP client used "
+                "for all outbound requests (GitHub API and Noteburst)."
+            ),
+        ),
+    ] = 30
+
     github_app_id: Annotated[
         int | None,
         Field(

--- a/src/timessquare/factory.py
+++ b/src/timessquare/factory.py
@@ -51,7 +51,7 @@ class ProcessContext:
     @classmethod
     async def create(cls) -> Self:
         """Create a ProcessContext from the application configuration."""
-        http_client = AsyncClient()
+        http_client = AsyncClient(timeout=config.http_client_timeout)
 
         redis_pool = BlockingConnectionPool.from_url(
             str(config.redis_url),

--- a/tests/factory_test.py
+++ b/tests/factory_test.py
@@ -1,0 +1,28 @@
+"""Tests for the process context and factory."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import Timeout
+
+from timessquare.config import config
+from timessquare.factory import ProcessContext
+
+
+def test_http_client_timeout_default() -> None:
+    """The HTTP client timeout config defaults to 30 seconds."""
+    assert config.http_client_timeout == 30
+
+
+@pytest.mark.asyncio
+async def test_process_context_http_client_timeout() -> None:
+    """ProcessContext.create() builds the shared client with the configured
+    timeout.
+    """
+    process_context = await ProcessContext.create()
+    try:
+        assert process_context.http_client.timeout == Timeout(
+            config.http_client_timeout
+        )
+    finally:
+        await process_context.aclose()


### PR DESCRIPTION
## Summary

- Construct the process-wide shared `httpx.AsyncClient` with an explicit, configurable timeout (default 30s) instead of inheriting httpx's implicit 5-second default, which tripped `httpx.ReadTimeout` during PR check-run setup when the GitHub API was merely slow.
- Add a `Config` field `http_client_timeout` (env var `TS_HTTP_CLIENT_TIMEOUT`, seconds, default 30), following the existing `gt=0` int convention used by `github_checkrun_timeout`.

## Validation steps

- Confirm the default: with no `TS_HTTP_CLIENT_TIMEOUT` set, `Config().http_client_timeout` is `30` and the shared client's `.timeout` is 30s on every axis.
- Set `TS_HTTP_CLIENT_TIMEOUT` to another positive integer and confirm the constructed client reflects it.

## References

- Closes #148
- PRD: #146
- Jira: https://rubinobs.atlassian.net/browse/DM-55466