### PR TITLE
DM-55466: Retry transient GitHub errors in check-run setup

### DIFF
--- a/changelog.d/20260710_000000_DM-55466.md
+++ b/changelog.d/20260710_000000_DM-55466.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- The GitHub content reads used during check-run setup (the `times-square.yaml` fetch, the recursive git tree fetch, and the notebook/sidecar blob fetches in `GitHubRepositoryCheckout`) now retry transient GitHub API errors in-task with exponential backoff and jitter. Transient network/timeout errors (httpx transport errors) and GitHub 5xx responses (`GitHubBroken`) are retried up to three times, while non-transient errors (4xx responses, validation errors, YAML syntax errors) fail fast. This lets a brief GitHub API slowdown self-heal instead of stranding a pull request's checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,9 @@ extend-exclude = [
 "src/timessquare/sentry.py" = [
     "S311",  # We're not using random.random for cryptography
 ]
+"src/timessquare/storage/github/retry.py" = [
+    "S311",  # Backoff jitter isn't security-sensitive
+]
 "src/timessquare/domain/schedule.py" = [
     "SLF001",  # Necessary evil to use private members
 ]

--- a/src/timessquare/domain/githubcheckout.py
+++ b/src/timessquare/domain/githubcheckout.py
@@ -17,6 +17,7 @@ from timessquare.storage.github.apimodels import (
     GitTreeMode,
     RecursiveGitTreeModel,
 )
+from timessquare.storage.github.retry import retry_transient_github_errors
 from timessquare.storage.github.settingsfiles import (
     NotebookSidecarFile,
     RepositorySettingsFile,
@@ -85,8 +86,10 @@ class GitHubRepositoryCheckout:
         git_ref: str | None = None,
     ) -> GitHubRepositoryCheckout:
         uri = repo.contents_url + "{?ref}"
-        data = await github_client.getitem(
-            uri, url_vars={"path": "times-square.yaml", "ref": head_sha}
+        data = await retry_transient_github_errors(
+            lambda: github_client.getitem(
+                uri, url_vars={"path": "times-square.yaml", "ref": head_sha}
+            )
         )
         content_data = GitHubBlobModel.model_validate(data)
         file_content = content_data.decode()
@@ -120,9 +123,11 @@ class GitHubRepositoryCheckout:
         tree
             The contents of the repository's git tree.
         """
-        response = await github_client.getitem(
-            self.trees_url + "{?recursive}",
-            url_vars={"sha": self.head_sha, "recursive": "1"},
+        response = await retry_transient_github_errors(
+            lambda: github_client.getitem(
+                self.trees_url + "{?recursive}",
+                url_vars={"sha": self.head_sha, "recursive": "1"},
+            )
         )
         git_tree = RecursiveGitTreeModel.model_validate(response)
         return RepositoryTree(github_tree=git_tree)
@@ -157,8 +162,10 @@ class GitHubRepositoryCheckout:
     async def load_git_blob(
         self, *, github_client: GitHubAPI, sha: str
     ) -> GitHubBlobModel:
-        data = await github_client.getitem(
-            self.blobs_url, url_vars={"sha": sha}
+        data = await retry_transient_github_errors(
+            lambda: github_client.getitem(
+                self.blobs_url, url_vars={"sha": sha}
+            )
         )
         return GitHubBlobModel.model_validate(data)
 

--- a/src/timessquare/storage/github/retry.py
+++ b/src/timessquare/storage/github/retry.py
@@ -1,0 +1,139 @@
+"""Retry helper for transient GitHub API errors.
+
+This module provides a small, isolated utility for making GitHub content
+reads self-heal through brief GitHub API slowness. It retries an awaitable
+GitHub call on *transient* errors (network/timeout errors and GitHub 5xx
+responses) with exponential backoff and jitter, and fails fast on everything
+else (e.g. GitHub 4xx, validation errors, YAML syntax errors), re-raising the
+last error once the bounded number of attempts is exhausted.
+
+The retry policy is a set of hardcoded, sensible constants rather than
+configuration knobs. The ``sleep`` callable is injectable so tests can run
+without actually waiting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from collections.abc import Awaitable, Callable
+
+import httpx
+from gidgethub import GitHubBroken
+
+__all__ = [
+    "INITIAL_BACKOFF",
+    "MAX_ATTEMPTS",
+    "MAX_BACKOFF",
+    "retry_transient_github_errors",
+]
+
+SleepCallable = Callable[[float], Awaitable[None]]
+"""Signature of an awaitable sleep, e.g. `asyncio.sleep`."""
+
+TRANSIENT_HTTPX_ERRORS: tuple[type[httpx.HTTPError], ...] = (
+    httpx.ReadTimeout,
+    httpx.ConnectTimeout,
+    httpx.ConnectError,
+    httpx.ReadError,
+    httpx.WriteError,
+    httpx.PoolTimeout,
+    httpx.RemoteProtocolError,
+)
+"""httpx transport/timeout errors that indicate a transient failure."""
+
+MAX_ATTEMPTS = 3
+"""Total number of attempts (the initial call plus retries)."""
+
+INITIAL_BACKOFF = 0.5
+"""Base backoff delay, in seconds, before the first retry."""
+
+MAX_BACKOFF = 5.0
+"""Ceiling for the backoff delay, in seconds."""
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """Classify whether an exception is a transient GitHub error worth
+    retrying.
+    """
+    return isinstance(exc, (*TRANSIENT_HTTPX_ERRORS, GitHubBroken))
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Compute the backoff delay before a retry with full jitter.
+
+    Parameters
+    ----------
+    attempt
+        The 1-based number of the attempt that just failed.
+
+    Returns
+    -------
+    float
+        Seconds to sleep before the next attempt.
+    """
+    delay = min(MAX_BACKOFF, INITIAL_BACKOFF * (2 ** (attempt - 1)))
+    return random.uniform(0, delay)
+
+
+async def retry_transient_github_errors[T](
+    call: Callable[[], Awaitable[T]],
+    *,
+    sleep: SleepCallable = asyncio.sleep,
+) -> T:
+    """Run a GitHub call, retrying it on transient errors with exponential
+    backoff and jitter.
+
+    Parameters
+    ----------
+    call
+        A zero-argument callable that returns a fresh awaitable each time it
+        is invoked (e.g. ``lambda: github_client.getitem(...)``). A new
+        awaitable is created for every attempt so each retry issues a fresh
+        request.
+    sleep
+        Awaitable sleep used between attempts. Injectable so tests can avoid
+        real delays; defaults to `asyncio.sleep`.
+
+    Returns
+    -------
+    T
+        The result of the first successful call.
+
+    Raises
+    ------
+    Exception
+        Re-raises the last transient error once `MAX_ATTEMPTS` is exhausted,
+        or immediately re-raises any non-transient error.
+
+    Examples
+    --------
+    Wrap a gidgethub request in a lambda rather than awaiting it directly,
+    so that the helper can re-invoke it to create a fresh request for each
+    attempt:
+
+    >>> data = await retry_transient_github_errors(
+    ...     lambda: github_client.getitem(
+    ...         "repos/{owner}/{repo}/contents/{path}{?ref}",
+    ...         url_vars={
+    ...             "owner": "lsst-sqre",
+    ...             "repo": "times-square-demo",
+    ...             "path": "times-square.yaml",
+    ...             "ref": head_sha,
+    ...         },
+    ...     )
+    ... )
+
+    Passing the coroutine itself (``retry_transient_github_errors(
+    github_client.getitem(...))``) would not work: a coroutine can only be
+    awaited once, so retries would fail.
+    """
+    for attempt in range(1, MAX_ATTEMPTS + 1):
+        try:
+            return await call()
+        except Exception as exc:
+            if not _is_transient(exc) or attempt >= MAX_ATTEMPTS:
+                raise
+            await sleep(_backoff_delay(attempt))
+    # Unreachable: the loop either returns or raises on the final attempt.
+    raise AssertionError("retry loop exited without returning or raising")

--- a/tests/domain/githubcheckout_test.py
+++ b/tests/domain/githubcheckout_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import httpx
 import pytest
 import respx
 from gidgethub.httpx import GitHubAPI
@@ -55,6 +56,59 @@ async def test_repository_git_tree(
     assert (
         repo_tree.github_tree.sha == "46372dfa5a432026d68d262899755ef0333ef8c0"
     )
+
+
+@pytest.mark.asyncio
+async def test_get_git_tree_retries_transient_error(
+    github_client: GitHubAPI,
+    respx_mock: respx.Router,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient httpx error while fetching the git tree is retried and
+    the checkout recovers (proves the retry helper is wired into the
+    GitHub reads).
+    """
+    # Make backoff instantaneous so the test does not actually wait.
+    monkeypatch.setattr(
+        "timessquare.storage.github.retry._backoff_delay",
+        lambda _attempt: 0.0,
+    )
+
+    json_path = Path(__file__).parent.joinpath(
+        "../data/rsp_broadcast/recursive_tree.json"
+    )
+    repo = GitHubRepositoryCheckout(
+        owner_name="lsst-sqre",
+        name="rsp_broadcast",
+        settings=RepositorySettingsFile(ignore=[]),
+        git_ref="refs/heads/main",
+        head_sha="46372dfa5a432026d68d262899755ef0333ef8c0",
+        trees_url=(
+            "https://api.github.com/repos/lsst-sqre/rsp_broadcast/git/trees/"
+            "46372dfa5a432026d68d262899755ef0333ef8c0"
+        ),
+        blobs_url=(
+            "https://api.github.com/repos/lsst-sqre/rsp_broadcast/git/blobs/"
+            "46372dfa5a432026d68d262899755ef0333ef8c0"
+        ),
+    )
+
+    route = respx_mock.get(
+        "https://api.github.com/repos/lsst-sqre/rsp_broadcast/git/trees/"
+        "46372dfa5a432026d68d262899755ef0333ef8c0?recursive=1"
+    )
+    route.side_effect = [
+        httpx.ReadTimeout("slow"),
+        Response(200, json=json.loads(json_path.read_text())),
+    ]
+
+    repo_tree = await repo.get_git_tree(github_client)
+
+    assert (
+        repo_tree.github_tree.sha == "46372dfa5a432026d68d262899755ef0333ef8c0"
+    )
+    # The first (timed-out) request was retried.
+    assert route.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/storage/github/retry_test.py
+++ b/tests/storage/github/retry_test.py
@@ -1,0 +1,112 @@
+"""Tests for the transient-GitHub-error retry helper."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from http import HTTPStatus
+
+import httpx
+import pytest
+from gidgethub import BadRequest, GitHubBroken
+
+from timessquare.storage.github.retry import (
+    MAX_ATTEMPTS,
+    retry_transient_github_errors,
+)
+
+
+class FakeSleep:
+    """An injectable async sleep that records durations instead of waiting."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+
+
+def make_flaky_call(
+    exc: BaseException, fail_times: int, result: str = "ok"
+) -> Callable[[], Awaitable[str]]:
+    """Build a zero-arg awaitable that raises ``exc`` the first ``fail_times``
+    invocations and then returns ``result``.
+    """
+    state = {"count": 0}
+
+    async def call() -> str:
+        if state["count"] < fail_times:
+            state["count"] += 1
+            raise exc
+        return result
+
+    return call
+
+
+@pytest.mark.asyncio
+async def test_retry_then_recover() -> None:
+    """A call that raises a transient error a couple of times and then
+    succeeds returns the success value.
+    """
+    sleep = FakeSleep()
+    call = make_flaky_call(httpx.ReadTimeout("slow"), fail_times=2)
+
+    result = await retry_transient_github_errors(call, sleep=sleep)
+
+    assert result == "ok"
+    # Slept once between each of the two failed attempts.
+    assert len(sleep.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_reraises_last_error() -> None:
+    """A call that always raises a transient error re-raises after the max
+    number of attempts.
+    """
+    sleep = FakeSleep()
+    call = make_flaky_call(httpx.ConnectError("down"), fail_times=1000)
+
+    with pytest.raises(httpx.ConnectError):
+        await retry_transient_github_errors(call, sleep=sleep)
+
+    # Bounded: slept between attempts but not after the final one.
+    assert len(sleep.calls) == MAX_ATTEMPTS - 1
+
+
+@pytest.mark.asyncio
+async def test_fail_fast_on_non_transient() -> None:
+    """A non-transient error is raised immediately without retrying."""
+    sleep = FakeSleep()
+    call = make_flaky_call(ValueError("nope"), fail_times=1000)
+
+    with pytest.raises(ValueError, match="nope"):
+        await retry_transient_github_errors(call, sleep=sleep)
+
+    assert sleep.calls == []
+
+
+@pytest.mark.asyncio
+async def test_fail_fast_on_github_4xx() -> None:
+    """A gidgethub 4xx error (e.g. BadRequest) is not retried."""
+    sleep = FakeSleep()
+    call = make_flaky_call(BadRequest(HTTPStatus.NOT_FOUND), fail_times=1000)
+
+    with pytest.raises(BadRequest):
+        await retry_transient_github_errors(call, sleep=sleep)
+
+    assert sleep.calls == []
+
+
+@pytest.mark.asyncio
+async def test_github_5xx_is_retried() -> None:
+    """A GitHub 5xx (gidgethub.GitHubBroken) is treated as transient and
+    retried.
+    """
+    sleep = FakeSleep()
+    call = make_flaky_call(
+        GitHubBroken(HTTPStatus.INTERNAL_SERVER_ERROR), fail_times=1
+    )
+
+    result = await retry_transient_github_errors(call, sleep=sleep)
+
+    assert result == "ok"
+    assert len(sleep.calls) == 1


### PR DESCRIPTION
## Summary

- The GitHub content reads used during check-run setup — the `times-square.yaml` fetch, the recursive git tree fetch, and the notebook/sidecar blob fetches in `GitHubRepositoryCheckout` — now retry transient GitHub API errors in-task with exponential backoff and jitter, so a brief GitHub slowdown self-heals instead of stranding a pull request's checks.
- Added a small, isolated, unit-tested retry helper (`storage/github/retry.py`) that retries httpx transport/timeout errors and GitHub 5xx (`GitHubBroken`) up to three attempts, and fails fast on non-transient errors (4xx, validation errors, YAML syntax errors), re-raising the last error on exhaustion. Its sleep is injectable so tests never wait.

## Validation steps

- No manual QA required; behavior is covered by unit tests (retry-then-recover, bounded-exhaustion re-raise, fail-fast on non-transient and 4xx, 5xx retried, and an integration test proving the checkout git-tree read is retried).

## References

- Closes #149
- PRD: #146
- Jira: https://rubinobs.atlassian.net/browse/DM-55466