### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,4 +209,3 @@ extend-exclude = [
 [tool.ruff.lint.isort]
 known-first-party = ["timessquare", "tests"]
 known-third-party = ["alembic"]
-split-on-trailing-comma = false

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -36,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

## Summary
- Refresh `ruff-shared.toml` from the `lsst/templates` `fastapi_safir_app` cookiecutter to pick up the single-line change from template commit dd8e4b26: ruff 0.16.0 stabilized `CPY001` (missing-copyright-notice) out of preview, and since this repo lints with `select = ["ALL"]`, the rule armed itself fleet-wide. The template now ignores `CPY001` explicitly.
- Prune the now-redundant `split-on-trailing-comma = false` override in `pyproject.toml`'s `[tool.ruff.lint.isort]` — the refreshed shared file already sets this value, so the local override was dead weight (toml-not-redundant check).

## Out of scope
`ruff check` also surfaces `PLR0917` (too-many-positional-arguments, newly stabilized in ruff 0.16) against `src/timessquare/services/page.py`, but only with ruff >=0.16 — the repo's pinned `ruff-pre-commit` rev is still 0.15.20, so local/pre-commit lint stays green. This is being handled separately as a per-site fix; this PR is config-only and does not touch source.

## Test plan
- [x] `uv run --with ruff ruff check .` passes clean at the pinned ruff version (0.15.20)
- [x] Confirmed with ruff 0.16.0 directly that the only new finding is the expected, out-of-scope `PLR0917` in `page.py`
- [x] Diffed `ruff-shared.toml` against the current `lsst/templates` `fastapi_safir_app` copy — confirmed the single `CPY001` ignore line is the only difference

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ