### PR TITLE
DM-55493: scope PLR0917 for ruff 0.16

### DIFF
--- a/src/timessquare/services/page.py
+++ b/src/timessquare/services/page.py
@@ -51,6 +51,7 @@ class PageService:
 
     def __init__(
         self,
+        *,
         page_store: PageStore,
         html_cache: NbHtmlCacheStore,
         job_store: NoteburstJobStore,
@@ -68,6 +69,7 @@ class PageService:
 
     async def create_page_with_notebook_from_upload(
         self,
+        *,
         ipynb: str,
         title: str,
         uploader_username: str,


### PR DESCRIPTION
## Background

ruff 0.16.0 stabilized `PLR0917` (*too-many-positional-arguments*), which was
previously in preview. Because our shared ruff config enables the `PL` ruleset,
upgrading the pinned ruff will surface this rule for the first time. Checking
this repo against ruff 0.16.0 specifically:

```
$ uvx ruff@0.16.0 check --select PLR0917,ISC004 .
PLR0917 Too many positional arguments (6 > 5)
  --> src/timessquare/services/page.py:52:9   # PageService.__init__
PLR0917 Too many positional arguments (7 > 5)
  --> src/timessquare/services/page.py:69:15  # create_page_with_notebook_from_upload
Found 2 errors.
```

(The pre-commit-pinned ruff in this repo is older and does not report these.)

`ISC004` reported nothing here, so no changes were needed for it.

## Disposition: fix, not a scoped ignore

Both findings are on `PageService`, an internal service API with a small,
fully-in-repo set of callers. Long positional argument lists of same-typed
collaborators (`page_store`, `html_cache`, `job_store`, ...) are exactly the
call-site-transposition hazard the rule exists to catch, so a per-file ignore
or `noqa` would be papering over a real readability issue rather than
recording a deliberate exception. Fixing is cheap and strictly improves the
API, so no `pyproject.toml` or `ruff-shared.toml` change is proposed.

## The change

Insert a bare `*` immediately after `self` in both signatures, making every
remaining parameter keyword-only:

- `PageService.__init__` — all six collaborators become keyword-only. There is
  no parameter here that reads naturally as positional; these are injected
  dependencies.
- `PageService.create_page_with_notebook_from_upload` — all seven become
  keyword-only. Four are already optional metadata with defaults, and the
  three required ones (`ipynb`, `title`, `uploader_username`) are all strings
  whose declaration order (`ipynb` before `title`) differs from the order the
  sole caller passes them in, which is precisely the kind of silent
  transposition bug keyword-only arguments prevent.

No parameters were removed, renamed, or reordered, and no `noqa` was added.

## Call sites

All call sites were audited before changing the signatures — `PageService(`,
`create_page_with_notebook_from_upload`, and `super().__init__(` across `src/`
and `tests/`:

- `src/timessquare/factory.py:233` (`PageService(...)`) — already keyword
- `src/timessquare/factory.py:246` (`BackgroundPageService(...)`) — already keyword
- `tests/handlers/v1/github_test.py:40` (`PageService(...)`) — already keyword
- `src/timessquare/handlers/v1/endpoints.py:238`
  (`create_page_with_notebook_from_upload(...)`) — already keyword

`BackgroundPageService` (`src/timessquare/services/backgroundpage.py`) is the
only subclass of `PageService` and does **not** override `__init__`, so there
is no `super().__init__()` call to update. **No caller changes were required.**

## Validation

- `uvx ruff@0.16.0 check --select PLR0917,ISC004 .` — clean (was 2 errors)
- `uvx ruff@0.16.0 check .` — clean under the repo's full config
- `nox -s typing test` — mypy clean; 79 passed, 1 pre-existing unrelated warning

No changelog fragment: this is an internal service-layer signature change in a
deployed application with no external API consumers, so there is nothing
user-visible to note.