### PR TITLE
DM-55493: Adopt prek in place of pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dev = [
     "httpx-sse == 0.4.0",
     "scriv",
     "freezegun>=1.5.2",
+    "uv",
 ]
 docs = [
     "documenteer[guide]>=1.0",
@@ -77,7 +78,6 @@ docs = [
 lint = [
     "prek",
     "ruff",
-    "uv",
 ]
 nox = [
     "nox",

--- a/scripts/update-uv-version.sh
+++ b/scripts/update-uv-version.sh
@@ -7,28 +7,34 @@
 # http://redsymbol.net/articles/unofficial-bash-strict-mode/ for details.
 set -euo pipefail
 
-# Determine the current frozen uv version. uv must be part of the lint
-# dependency group in pyproject.toml.
-uv_version=$(uv export -q --no-hashes --only-group lint \
-             | grep ^uv== | sed 's/.*=//')
+# Expand non-matching globs to the empty list instead of the glob so that
+# packages that don't have one of the affected files can silently skip the
+# uv version rewrite rule that doesn't apply.
+shopt -s nullglob
+
+# Determine the current uv release version.
+uv_version=$(echo uv \
+             | uv pip compile - --quiet --no-header --no-annotate --no-config \
+             | sed -n 's/^uv==//p')
 
 # Replace the version in the env variables in GitHub Actions workflows.
 for f in .github/workflows/*.yaml; do
     sed "s/UV_VERSION: .*/UV_VERSION: \"$uv_version\"/" "$f" >"$f.n"
     if ! cmp -s "$f" "${f}.n"; then
-	echo "Updating UV_VERSION to $uv_version in $f"
-	mv "${f}.n" "$f"
+        echo "Updating UV_VERSION to $uv_version in $f"
+        mv "${f}.n" "$f"
     else
         rm "${f}.n"
     fi
 done
 
-# Replace the version in any Dockerfiles.
+# Replace the version in any Dockerfiles. Allow for copying this script into
+# packages that have no Dockerfile.
 for f in Dockerfile*; do
     sed "s/uv:[0-9][0-9.]*/uv:$uv_version/" "$f" >"${f}.n"
     if ! cmp -s "$f" "${f}.n"; then
         echo "Updating uv container version to $uv_version in $f"
-	mv "${f}.n" "$f"
+        mv "${f}.n" "$f"
     else
         rm "${f}.n"
     fi

--- a/uv.lock
+++ b/uv.lock
@@ -2641,6 +2641,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "respx" },
     { name = "scriv" },
+    { name = "uv" },
     { name = "uvicorn" },
 ]
 docs = [
@@ -2649,7 +2650,6 @@ docs = [
 lint = [
     { name = "prek" },
     { name = "ruff" },
-    { name = "uv" },
 ]
 nox = [
     { name = "nox" },
@@ -2702,13 +2702,13 @@ dev = [
     { name = "pytest-mock" },
     { name = "respx" },
     { name = "scriv" },
+    { name = "uv" },
     { name = "uvicorn" },
 ]
 docs = [{ name = "documenteer", extras = ["guide"], specifier = ">=1.0" }]
 lint = [
     { name = "prek" },
     { name = "ruff" },
-    { name = "uv" },
 ]
 nox = [
     { name = "nox" },


### PR DESCRIPTION
Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

times-square was already half-migrated to prek: the `lint` dependency
group already listed `prek` and `ruff`, and `Makefile`, `noxfile.py`, and
the CI workflows already invoked `prek` instead of `pre-commit`. This PR
finishes the migration, matching the reference PR lsst-sqre/noteburst#161:

- Moved `uv` out of the `lint` dependency group and into `dev` (step 3),
  since `dev` didn't have it yet.
- Refreshed `scripts/update-uv-version.sh` to the current
  `lsst/templates` version (step 7), since the file already existed but
  had drifted from the template.
- Re-ran `uv lock` to reconcile the lockfile; the diff is limited to the
  dependency-group entries (no `fastapi` movement).

Taskrunner branch: this is a **nox** repo (no `tox.ini`), and the `lint`
session in `noxfile.py` already ran `prek run --all-files` — no change
needed there.

`.pre-commit-config.yaml` is untouched, as directed.

Verified:
- `uv run --only-group=lint prek run --all-files` passes
- `uv run --only-group=nox nox -s lint` passes
- done-check greps (steps 12) all pass; `lint` group is `[prek, ruff]`,
  `dev` group contains `uv`

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ