### PR TITLE
DM-55467: Make the schedule-rule timezone validator None-safe

### DIFF
--- a/changelog.d/20260730_000000_jonathan_DM_55467.md
+++ b/changelog.d/20260730_000000_jonathan_DM_55467.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fixed scheduled page execution for recurring schedules that terminate with a `count` rather than an `end` date. The timezone-normalizing validator on schedule-rule datetime fields is now `None`-safe, so the optional `end` field of a from-date rule survives a serialize/deserialize round trip. Previously such a schedule was persisted with an explicit `"end": null`, and re-parsing that stored form raised `AttributeError: 'NoneType' object has no attribute 'tzinfo'` on every `schedule_runs` cron tick, preventing the page from ever being scheduled. Affected pages resume scheduling on the next cron tick with no data migration required.

--- a/src/timessquare/domain/schedulerule.py
+++ b/src/timessquare/domain/schedulerule.py
@@ -147,11 +147,23 @@ def ensure_byweekday_object(value: Any) -> Any:
     return values
 
 
-def ensure_timezone_aware(value: datetime) -> datetime:
+def ensure_timezone_aware(value: datetime | None) -> datetime | None:
     """Ensure that the datetime is timezone aware, defaulting to UTC.
 
     Use as an after-validator.
+
+    Notes
+    -----
+    ``None`` is passed through unchanged so that this validator can be
+    attached to optional datetime fields such as `ScheduleFromDate.end`.
+    Pydantic skips after-validators when a field is absent and its default is
+    used, but it *does* run them against an explicit ``null``. Since
+    `ScheduleRules.serialize_to_json` dumps with ``exclude_none=False``, an
+    unset optional field is persisted as ``null`` and is re-validated here on
+    every deserialization.
     """
+    if value is None:
+        return None
     if value.tzinfo is None:
         return value.replace(tzinfo=UTC)
     return value

--- a/tests/domain/schedule_test.py
+++ b/tests/domain/schedule_test.py
@@ -9,7 +9,10 @@ from dateutil.rrule import rruleset
 from freezegun import freeze_time
 
 from timessquare.domain.schedule import RunSchedule
-from timessquare.domain.schedulerule import ScheduleRules
+from timessquare.domain.schedulerule import (
+    ScheduleRules,
+    ensure_timezone_aware,
+)
 
 
 @freeze_time("2020-01-01 00:00:00", tz_offset=0)
@@ -164,3 +167,61 @@ def test_schedule_by_minute() -> None:
     next_run = schedule.next(datetime(2025, 6, 5, 19, 45, tzinfo=UTC))
     # Note that the start is forced as UTC
     assert next_run == datetime(2025, 6, 5, 19, 50, tzinfo=UTC)
+
+
+@freeze_time("2026-04-11 00:00:00", tz_offset=0)
+def test_schedule_from_date_with_count_json_roundtrip() -> None:
+    """A from-date rule bounded by ``count`` (and therefore with no ``end``)
+    must survive a serialize/deserialize round trip.
+
+    ``ScheduleRules.serialize_to_json`` dumps with ``exclude_none=False``, so
+    the unset ``end`` is persisted as an explicit ``null``. Re-parsing that
+    stored form must not raise (DM-55467).
+    """
+    schedule_json = json.dumps(
+        [
+            {
+                "start": "2025-12-01T14:00:00Z",
+                "freq": "weekly",
+                "interval": 2,
+                "count": 300,
+            }
+        ]
+    )
+    schedule = RunSchedule(schedule_json, enabled=True)
+
+    # Serialize the way the page store persists the schedule.
+    serialized = schedule.rules.serialize_to_json()
+    assert '"end":null' in serialized.replace(" ", "")
+
+    # Re-parsing the persisted form is what runs on every schedule_runs tick.
+    deserialized_schedule = RunSchedule(serialized, enabled=True)
+    assert isinstance(deserialized_schedule.rules, ScheduleRules)
+    assert isinstance(deserialized_schedule.rruleset, rruleset)
+
+    next_run = deserialized_schedule.next(
+        datetime(2026, 4, 11, 0, 0, tzinfo=UTC)
+    )
+    # The recurrence starts Monday 2025-12-01 and repeats every two weeks;
+    # 2026-04-20 is the first occurrence after 2026-04-11.
+    assert next_run == datetime(2026, 4, 20, 14, 0, tzinfo=UTC)
+    assert next_run == schedule.next(datetime(2026, 4, 11, 0, 0, tzinfo=UTC))
+
+
+def test_ensure_timezone_aware_passes_none_through() -> None:
+    """The timezone-aware validator returns ``None`` unchanged."""
+    assert ensure_timezone_aware(None) is None
+
+
+def test_ensure_timezone_aware_normalizes_naive_datetime() -> None:
+    """The timezone-aware validator assumes UTC for naive datetimes."""
+    naive = datetime(2025, 12, 1, 14, 0)  # noqa: DTZ001
+    assert ensure_timezone_aware(naive) == datetime(
+        2025, 12, 1, 14, 0, tzinfo=UTC
+    )
+
+
+def test_ensure_timezone_aware_preserves_aware_datetime() -> None:
+    """The timezone-aware validator leaves aware datetimes untouched."""
+    aware = datetime(2025, 12, 1, 14, 0, tzinfo=UTC)
+    assert ensure_timezone_aware(aware) is aware


### PR DESCRIPTION
## Summary

- Fix scheduled page execution for recurring schedules that terminate with a `count` instead of an `end` date. The timezone-normalizing after-validator on schedule-rule datetime fields now passes `None` through unchanged, so the optional `end` of a from-date rule survives a serialize/deserialize round trip.
- Previously such a schedule was persisted as `"end": null` (`serialize_to_json()` dumps with `exclude_none=False`), and re-parsing that stored form raised `AttributeError: 'NoneType' object has no attribute 'tzinfo'` on every `schedule_runs` cron tick — ~26,000 Sentry events since 2026-04-11 for a single `usdfprod` page, which was never scheduled.
- Add a regression test that round-trips the reported schedule (start `2025-12-01T14:00:00Z`, weekly, interval 2, `count: 300`) through `ScheduleRules.serialize_to_json()` and asserts `RunSchedule.next()` returns the correct occurrence, plus unit coverage of the validator's `None` / naive / aware behavior.

No database migration or data patch is required — the affected page self-heals on the next cron tick once this deploys.

## Validation steps

- After deploy, confirm the `schedule_runs` cron tick no longer logs "Failed to schedule page execution" for page `33f4908ff5284ab6a566988af62ca37a`, and that the matching Sentry issue stops receiving new events.
- Confirm that page now has a populated next-scheduled-run time and executes at its next occurrence (every two weeks, 14:00 UTC).
- Spot-check that pages with `end`-bounded and fixed-date schedules still schedule as before.

## References

- Closes #151
- PRD: #147
- Jira: https://rubinobs.atlassian.net/browse/DM-55467