### PR TITLE
DM-55467: Validate sidecar run schedules in the configs check

### DIFF
--- a/changelog.d/20260730_140000_jsick_DM_55467_ingest.md
+++ b/changelog.d/20260730_140000_jsick_DM_55467_ingest.md
@@ -1,0 +1,3 @@
+### New features
+
+- The GitHub YAML config check now validates a notebook sidecar's run schedule at ingest time. After the sidecar's YAML and schema validation, Times Square serializes the schedule exactly as it will be stored and computes the next occurrence from it; if that fails, the check run gets a failure annotation on the sidecar file instead of the broken schedule silently landing on `main` and failing later in the scheduler.

--- a/src/timessquare/domain/githubcheckrun.py
+++ b/src/timessquare/domain/githubcheckrun.py
@@ -37,6 +37,7 @@ from .githubcheckout import (
     RepositoryTree,
 )
 from .page import PageExecutionInfo, PageModel
+from .schedule import RunSchedule
 
 TRANSIENT_CHECKOUT_ERROR_MESSAGE = (
     "Times Square could not read the repository's contents from GitHub "
@@ -44,6 +45,10 @@ TRANSIENT_CHECKOUT_ERROR_MESSAGE = (
 )
 """Actionable message shown when a repository checkout fails because of a
 transient GitHub error that outlasted the retry budget."""
+
+SCHEDULE_EVALUATION_ERROR_TITLE = "Unevaluatable schedule"
+"""Annotation title used when a sidecar's schedule validates against the
+schema but cannot be evaluated once serialized."""
 
 
 @dataclass(kw_only=True)
@@ -400,8 +405,9 @@ class GitHubConfigsCheck(GitHubCheck):
             )
         )
         sidecar_blob = GitHubBlobModel.model_validate(data)
+        sidecar: NotebookSidecarFile | None = None
         try:
-            NotebookSidecarFile.parse_yaml(sidecar_blob.decode())
+            sidecar = NotebookSidecarFile.parse_yaml(sidecar_blob.decode())
         except ValidationError as e:
             annotations = Annotation.from_validation_error(
                 path=notebook_ref.sidecar_path, error=e
@@ -412,7 +418,55 @@ class GitHubConfigsCheck(GitHubCheck):
                 path=notebook_ref.sidecar_path, error=e
             )
             self.annotations.extend(annotations)
+        if sidecar is not None:
+            self.validate_schedule(
+                sidecar=sidecar, path=notebook_ref.sidecar_path
+            )
         self.sidecar_files_checked.append(notebook_ref.sidecar_path)
+
+    def validate_schedule(
+        self, *, sidecar: NotebookSidecarFile, path: str
+    ) -> None:
+        """Validate a sidecar's run schedule by exercising it the way it will
+        be stored and evaluated, adding a failure annotation if it raises.
+
+        The sidecar schema validates individual rule fields, but a rule set
+        that satisfies the schema can still serialize to an rruleset that
+        dateutil refuses to build or evaluate. Catching that here keeps an
+        un-runnable schedule from being ingested.
+
+        Parameters
+        ----------
+        sidecar
+            The parsed sidecar file.
+        path
+            Repository path of the sidecar file, used as the annotation's
+            path.
+        """
+        run_schedule = sidecar.run_schedule
+        if run_schedule is None:
+            return
+
+        # Evaluate the schedule as if it were enabled: ``schedule_enabled`` is
+        # a runtime toggle, and RunSchedule.next short-circuits when it is
+        # off. A schedule that cannot be evaluated is a defect whether or not
+        # it is currently switched on.
+        probe = RunSchedule(run_schedule.schedule_json, enabled=True)
+        try:
+            probe.next(None)
+        except Exception as e:
+            self.annotations.append(
+                Annotation(
+                    path=path,
+                    start_line=1,
+                    message=(
+                        "Times Square could not compute the next run from "
+                        f"this schedule: {e}"
+                    ),
+                    title=SCHEDULE_EVALUATION_ERROR_TITLE,
+                    annotation_level=GitHubCheckRunAnnotationLevel.failure,
+                )
+            )
 
     @property
     def conclusion(self) -> GitHubCheckRunConclusion:

--- a/tests/domain/githubcheckrun_test.py
+++ b/tests/domain/githubcheckrun_test.py
@@ -1,8 +1,10 @@
 """Tests for the githubcheckrun domain.
 
-Two areas are covered:
+Three areas are covered:
 
 - graceful handling of transient GitHub errors during repository checkout;
+- ingest-time validation of a notebook sidecar's run schedule by the configs
+  check;
 - the annotations and recorded execution status produced by
   `NotebookExecutionsCheck.report_noteburst_completion`, which derives both
   from the shared execution-outcome classifier
@@ -28,6 +30,7 @@ from safir.github.models import (
 from safir.github.webhooks import GitHubCheckSuiteEventModel
 
 from timessquare.domain.githubcheckrun import (
+    SCHEDULE_EVALUATION_ERROR_TITLE,
     TRANSIENT_CHECKOUT_ERROR_MESSAGE,
     GitHubConfigsCheck,
     NotebookExecutionsCheck,
@@ -206,6 +209,89 @@ async def test_validate_repo_propagates_non_transient_error() -> None:
             repo=payload.repository,
             head_sha=payload.check_suite.head_sha,
         )
+
+
+UNEVALUATABLE_SCHEDULE_SIDECAR = """
+title: Broken schedule
+schedule:
+  - freq: monthly
+    weekday: friday
+    set_position: 0
+"""
+"""A sidecar that validates as YAML and against the sidecar schema, but whose
+schedule rule serializes to an rruleset dateutil refuses to build
+(``set_position`` is not range-checked by the sidecar schema).
+"""
+
+FROM_DATE_COUNT_SCHEDULE_SIDECAR = """
+title: Counted schedule
+schedule:
+  - start: 2026-01-01T12:00:00Z
+    freq: daily
+    count: 5
+"""
+"""A legitimate from-date/``count`` schedule. Its serialized form carries
+``"end": null``, which is the round-trip that used to break schedule
+evaluation, so it must not produce an annotation.
+"""
+
+
+@pytest.mark.asyncio
+async def test_validate_sidecar_annotates_unevaluatable_schedule() -> None:
+    """A sidecar whose schedule cannot be evaluated fails the configs check
+    with a failure annotation on the sidecar's path.
+    """
+    payload = _load_check_suite()
+    mock = MockGitHubCheckRunAPI(
+        check_run=_load_check_run(),
+        sidecar_content=UNEVALUATABLE_SCHEDULE_SIDECAR,
+    )
+    client = cast("GitHubAPI", mock)
+
+    check = await GitHubConfigsCheck.create_check_run_and_validate(
+        github_client=client,
+        repo=payload.repository,
+        head_sha=payload.check_suite.head_sha,
+    )
+    await check.submit_conclusion(github_client=client)
+
+    schedule_annotations = [
+        a
+        for a in check.annotations
+        if a.title == SCHEDULE_EVALUATION_ERROR_TITLE
+    ]
+    assert len(schedule_annotations) == 1
+    annotation = schedule_annotations[0]
+    assert annotation.path == "demo.yaml"
+    assert annotation.annotation_level == GitHubCheckRunAnnotationLevel.failure
+    assert "bysetpos" in annotation.message
+
+    assert check.conclusion == GitHubCheckRunConclusion.failure
+    assert mock.patched[-1]["conclusion"] == GitHubCheckRunConclusion.failure
+
+
+@pytest.mark.asyncio
+async def test_validate_sidecar_accepts_from_date_count_schedule() -> None:
+    """A valid from-date/``count`` schedule passes the configs check with no
+    annotation, so the ingest-time check raises no false failure.
+    """
+    payload = _load_check_suite()
+    mock = MockGitHubCheckRunAPI(
+        check_run=_load_check_run(),
+        sidecar_content=FROM_DATE_COUNT_SCHEDULE_SIDECAR,
+    )
+    client = cast("GitHubAPI", mock)
+
+    check = await GitHubConfigsCheck.create_check_run_and_validate(
+        github_client=client,
+        repo=payload.repository,
+        head_sha=payload.check_suite.head_sha,
+    )
+    await check.submit_conclusion(github_client=client)
+
+    assert check.annotations == []
+    assert check.conclusion == GitHubCheckRunConclusion.success
+    assert mock.patched[-1]["conclusion"] == GitHubCheckRunConclusion.success
 
 
 def _base_response(**kwargs: object) -> NoteburstJobResponseModel:

--- a/tests/domain/githubcheckrun_test.py
+++ b/tests/domain/githubcheckrun_test.py
@@ -264,7 +264,15 @@ async def test_validate_sidecar_annotates_unevaluatable_schedule() -> None:
     annotation = schedule_annotations[0]
     assert annotation.path == "demo.yaml"
     assert annotation.annotation_level == GitHubCheckRunAnnotationLevel.failure
-    assert "bysetpos" in annotation.message
+    # Assert on Times Square's own message, not on the underlying dateutil
+    # error wording, which is not a stable contract. The trailing detail is
+    # still checked for non-emptiness so the exception text keeps reaching
+    # the annotation.
+    message_prefix = (
+        "Times Square could not compute the next run from this schedule: "
+    )
+    assert annotation.message.startswith(message_prefix)
+    assert annotation.message.removeprefix(message_prefix).strip()
 
     assert check.conclusion == GitHubCheckRunConclusion.failure
     assert mock.patched[-1]["conclusion"] == GitHubCheckRunConclusion.failure

--- a/tests/support/github.py
+++ b/tests/support/github.py
@@ -135,6 +135,18 @@ CHECK_RUN_GIT_TREE: dict[str, Any] = {
 """
 
 
+def _blob(content: bytes) -> dict[str, Any]:
+    """Build a GitHub git blob response body carrying ``content``."""
+    encoded = base64.b64encode(content).decode()
+    return {
+        "content": encoded,
+        "encoding": "base64",
+        "url": "https://api.github.com/repos/x/y/git/blobs/abc123",
+        "sha": "abc123",
+        "size": len(encoded),
+    }
+
+
 class MockGitHubCheckRunAPI(MockGitHubAPI):
     """A concrete `MockGitHubAPI` for exercising the GitHub check-run flow.
 
@@ -150,9 +162,11 @@ class MockGitHubCheckRunAPI(MockGitHubAPI):
     When ``contents_error`` is not set, the Contents GET returns a valid,
     empty ``times-square.yaml`` blob so the checkout succeeds. When
     ``tree_error`` is not set, the git tree GET returns `CHECK_RUN_GIT_TREE`,
-    so the check reaches the notebook-loading blob GETs. Those blob GETs are
-    only meaningful with ``blob_error`` set; there is no canned notebook
-    content behind them.
+    so the check reaches the notebook-loading blob GETs. Pass
+    ``sidecar_content`` to serve that YAML as the body of every git blob GET,
+    which is what the configs check reads as the notebook's sidecar file;
+    without it there is no canned content behind those GETs and they are only
+    meaningful with ``blob_error`` set.
     """
 
     def __init__(
@@ -162,6 +176,7 @@ class MockGitHubCheckRunAPI(MockGitHubAPI):
         contents_error: BaseException | None = None,
         tree_error: BaseException | None = None,
         blob_error: BaseException | None = None,
+        sidecar_content: str | None = None,
         oauth_token: str | None = None,
         cache: gh_abc.CACHE_TYPE | None = None,
         base_url: str = sansio.DOMAIN,
@@ -173,6 +188,7 @@ class MockGitHubCheckRunAPI(MockGitHubAPI):
         self._contents_error = contents_error
         self._tree_error = tree_error
         self._blob_error = blob_error
+        self._sidecar_content = sidecar_content
         self.requests: list[tuple[str, str]] = []
         self.patched: list[dict[str, Any]] = []
 
@@ -211,21 +227,20 @@ class MockGitHubCheckRunAPI(MockGitHubAPI):
         bodies of PATCH requests (the in-progress and conclusion updates).
 
         The ``times-square.yaml`` Contents GET instead returns a valid,
-        empty settings-file blob so a checkout can succeed, and the recursive
-        git tree GET returns `CHECK_RUN_GIT_TREE`.
+        empty settings-file blob so a checkout can succeed, the recursive
+        git tree GET returns `CHECK_RUN_GIT_TREE`, and the git blob GETs
+        return ``sidecar_content`` when it was provided.
         """
         if method == "GET" and "times-square.yaml" in url:
-            content = base64.b64encode(b'root: ""\n').decode()
-            blob = {
-                "content": content,
-                "encoding": "base64",
-                "url": "https://api.github.com/repos/x/y/git/blobs/abc123",
-                "sha": "abc123",
-                "size": len(content),
-            }
-            return 200, blob, {}
+            return 200, _blob(b'root: ""\n'), {}
         if method == "GET" and "git/trees" in url:
             return 200, CHECK_RUN_GIT_TREE, {}
+        if (
+            method == "GET"
+            and "git/blobs" in url
+            and self._sidecar_content is not None
+        ):
+            return 200, _blob(self._sidecar_content.encode()), {}
         if method == "PATCH" and request_json is not None:
             self.patched.append(request_json)
         return 200, self._check_run, {}


### PR DESCRIPTION
## Summary

- The GitHub YAML config check now exercises each notebook sidecar's run schedule the way Times Square will actually store and evaluate it — serializing the rules to the rruleset JSON and computing a next occurrence — and adds a check-run failure annotation on the sidecar's path if that raises. A schedule that satisfies the sidecar schema but serializes to an un-evaluatable rruleset is now caught at PR review time instead of silently failing on every `schedule_runs` cron tick after merge.
- The annotation reuses the existing `Annotation` / check-run machinery already used for `times-square.yaml` and sidecar validation failures, so a broken schedule fails the config check and (as before) skips the notebook-execution check.
- `MockGitHubCheckRunAPI` gained a `sidecar_content` argument so tests can serve canned sidecar YAML from the git blob GETs, rather than adding a second mock.

**Stacked PR:** this branch is stacked on `tickets/DM-55467-none-safe-validator` (#174) and is based on it rather than `main`, because the ingest check depends on the `None`-safe schedule-rule validator fix. Before that fix, a legitimate from-date/`count` schedule fails the serialize/deserialize round trip and this check would falsely reject it. Merge #174 first; GitHub will retarget this PR to `main` automatically.

## Validation steps

- Open a PR in a Times Square notebook repo whose sidecar contains a schedule that the schema accepts but dateutil cannot build (e.g. a monthly rule with `set_position: 0`). Confirm the "YAML config validation" check run concludes as a failure with an "Unevaluatable schedule" annotation attached to the sidecar file, and that the "Notebook execution" check run is skipped (neutral).
- Open a PR whose sidecar carries a valid from-date/`count` schedule (`start` + `freq` + `count`, no `end`). Confirm the config check still concludes green with no annotation on the sidecar.
- Confirm a sidecar with no `schedule` key at all is unaffected and still passes the check.

## References

- Closes #153
- PRD: #147
- Jira: https://rubinobs.atlassian.net/browse/DM-55467